### PR TITLE
Test: Invalid release note entry (should FAIL CI)

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -78,6 +78,7 @@ Back Porting
 ------------
 
 ### Bug Fixes
+* Fixed a bug with release notes
 
 ### Contributors
 


### PR DESCRIPTION
This PR tests the release notes CI check with an **invalid** entry.

The entry added:
```
* Fixed a bug with release notes
```

This is missing the required `by @<author> (#<PR>)` suffix.

Expected result: The "Release Notes Check" workflow should **fail** ❌