### PR TITLE
RDMA: capture CI kernel log on failure and add server accept error detail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,9 @@ jobs:
       - name: test
         run: sudo ./runtest-rdma --install-rxe
       - name: show-kernel-log
+        # Always dump the kernel ring buffer, including on test failure, so that
+        # soft-RoCE (rxe) errors behind an RDMA failure are captured in CI logs.
+        if: always()
         run: sudo dmesg -c
 
   test-tls-only:

--- a/src/rdma.c
+++ b/src/rdma.c
@@ -808,12 +808,13 @@ static int rdmaHandleConnect(aeEventLoop *el, char *err, struct rdma_cm_event *e
 
     cm_id->context = ctx;
     if (rdmaCreateResource(ctx, cm_id) == C_ERR) {
+        serverRdmaError(err, "RDMA: create resource failed");
         goto reject;
     }
 
     ret = rdma_accept(cm_id, &conn_param);
     if (ret) {
-        serverRdmaError(err, "RDMA: accept failed");
+        serverRdmaError(err, "RDMA: accept failed: %s", strerror(errno));
         goto free_rdma;
     }
 


### PR DESCRIPTION
## Problem

`test-rdma` in `.github/workflows/ci.yml` flakes on ~7% of `ci.yml` runs. The dominant failure is the server rejecting the client's connection on the `rdma_accept()` path. A failing job shows the server logging that it is ready, then rejecting all four client threads:

```
# RDMA Accepting client connection: RDMA: accept failed
# RDMA Accepting client connection: RDMA: accept failed
# RDMA Accepting client connection: RDMA: accept failed
# RDMA Accepting client connection: RDMA: accept failed
valkeyRdmaCM:733 RDMA: connect failed - RDMA_CM_EVENT_REJECTED
rdma-test: rdma-test.c:733: valkeyRdmaCM: Assertion `0' failed.
```

Example: https://github.com/valkey-io/valkey/actions/runs/32069135311/job/95509392279

The underlying soft-RoCE (rxe) error that causes `rdma_accept()` to fail cannot currently be attributed, because of three observability gaps:

1. `.github/workflows/ci.yml` — the `show-kernel-log` step (`sudo dmesg -c`) has no `if: always()`, so the kernel ring buffer is dumped only when the test passes and is discarded on every failure. On failure, the rxe error that would explain the rejection is lost.
2. `src/rdma.c:810` — the accept failure is reported as `serverRdmaError(err, "RDMA: accept failed")` with no `errno`, so we never learn why `rdma_accept()` returned an error.
3. `src/rdma.c:804-805` — when `rdmaCreateResource()` fails, `rdmaHandleConnect()` does `goto reject` without setting `err`, so that variant surfaces an empty reason.

## Change

- `.github/workflows/ci.yml`: add `if: always()` to `show-kernel-log` so the kernel log is captured on failure too.
- `src/rdma.c`: append `strerror(errno)` to the accept-failure message (matches the existing idiom at `src/rdma.c:863`, `src/rdma.c:1032`), and set an explicit reason on the `rdmaCreateResource()` failure path.

These are observability-only changes; no runtime behavior is altered.

## Testing

Not tested at runtime: I could not build or run the RDMA module locally — the `librdmacm`/`libibverbs` development headers were unavailable in my environment and I had no way to install them. The change is limited to log strings and a CI `if:` condition. The two `src/rdma.c` idioms used (`strerror(errno)` and a variadic `serverRdmaError(...)` format) already exist elsewhere in the same file (`src/rdma.c:863`, `src/rdma.c:1548`).

This was generated by AI but verified, with love, by a human.
