### PR TITLE
RDMA: derive test client resolve timeouts from connection budget

### DIFF
--- a/tests/rdma/rdma-test.c
+++ b/tests/rdma/rdma-test.c
@@ -704,8 +704,11 @@ static int valkeyRdmaCM(RdmaContext *ctx, int timeout) {
         /* printf("GET RDMA CM EVENT: %s\n", rdma_event_str(event->event)); */
         switch (event->event) {
         case RDMA_CM_EVENT_ADDR_RESOLVED:
-            if (timeout < 0 || timeout > 100)
-                timeout = 100; /* at most 100ms to resolve route */
+            /* Resolve the route within the remaining connection budget, with a
+             * 100ms floor. A hard 100ms cap is too tight on loaded CI hosts
+             * (e.g. soft-RoCE), causing spurious route-resolve timeouts. */
+            if (timeout < 100)
+                timeout = 100;
             ret = rdma_resolve_route(event->id, timeout);
             if (ret) {
                 rdmaFatal("RDMA: route resolve failed");
@@ -826,8 +829,13 @@ static RdmaContext *valkeyContextConnectRdma(const char *addr, int port, int tim
             goto free_rdma;
         }
 
-        /* resolve addr as most 100ms */
-        if (rdma_resolve_addr(ctx->cm_id, NULL, (struct sockaddr *)&saddr, 100)) {
+        /* Resolve the address within the remaining connection budget, with a
+         * 100ms floor, rather than a fixed 100ms which is too tight on loaded
+         * CI hosts (e.g. soft-RoCE) and caused spurious "resolve failed". */
+        timed = timeout - (valkeyNowMs() - start);
+        if (timed < 100)
+            timed = 100;
+        if (rdma_resolve_addr(ctx->cm_id, NULL, (struct sockaddr *)&saddr, timed)) {
             continue;
         }
 


### PR DESCRIPTION
## Problem

The RDMA test client intermittently aborts during connection setup on loaded GitHub-hosted runners using soft-RoCE (rxe):

```
valkeyContextConnectRdma:842 RDMA: resolve failed
valkeyContextConnectRdma:842 RDMA: resolve failed
valkeyContextConnectRdma:842 RDMA: resolve failed
```

Observed on run 32069135311.

The client is given a 1000ms connection budget (`tests/rdma/rdma-test.c` `test_routine()` calls `valkeyContextConnectRdma(host, port, 1000)`), but two resolution steps ignore that budget and use a fixed 100ms instead:

- `tests/rdma/rdma-test.c:830` — `rdma_resolve_addr(ctx->cm_id, NULL, ..., 100)` always passes a hardcoded 100ms, regardless of how much of the connection budget remains.
- `tests/rdma/rdma-test.c:707-709` — in `valkeyRdmaCM()`, the route-resolve timeout is capped at 100ms (`if (timeout < 0 || timeout > 100) timeout = 100`), even when more budget is available.

On a busy runner, address/route resolution over rxe intermittently takes longer than 100ms, so the client gives up early and asserts, even though it was told it had a full second.

## Change

Derive both timeouts from the remaining connection budget, with a 100ms floor:

- `rdma_resolve_addr()` is given `timeout - elapsed` (floored at 100ms) instead of a fixed 100ms.
- The route-resolve cap becomes a 100ms floor (`if (timeout < 100) timeout = 100`), so route resolution may use up to the remaining budget.

This lets the client use the full window it was already given instead of failing at 100ms. It only touches the test client; the server-side `rdma_accept()` rejection is a separate signature tracked in the observability PR.

## Testing

Not tested at runtime: I could not build or run the RDMA module locally (no `librdmacm`/`libibverbs` development headers available, no way to install them). The change is confined to timeout arithmetic; `timed` is already declared in the function, and the test binary is built without `-Werror`/`-Wconversion` (`tests/rdma/Makefile`), so the `long`→`int` timeout argument is fine. `tests/rdma/rdma-test.c` is intentionally outside clang-format enforcement (the CI job in `.github/workflows/clang-format.yml` runs `cd src` first), so the edits were hand-formatted to match the file's existing 4-space style.

This was generated by AI but verified, with love, by a human.
