### PR TITLE
Tests: deflake WATCHed-key-expiry test under valgrind

### DIFF
--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -48,13 +48,28 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         assert {[R 0 cluster keyslot $watched_key] != [R 0 cluster keyslot $transaction_key]}
 
         # The TTL is set before WATCH, and the key is still in the keyspace once it elapses, so nothing but
-        # the key having expired can abort the transaction.
+        # the key having expired can abort the transaction. Re-arming the TTL after WATCH is not an option:
+        # EXPIRE and SET signal the key as modified, which would abort EXEC for the wrong reason.
         R 0 debug set-active-expire 0
         R 0 del $transaction_key
-        R 0 set $watched_key alive px 50
-        R 0 watch $watched_key
+
+        # The key must still be alive when WATCH runs, otherwise the server remembers it as already expired
+        # and deliberately lets EXEC commit. A round trip can take tens of milliseconds under valgrind, so
+        # start with a short TTL and retry with a longer one until PTTL confirms the key outlived WATCH.
+        # PTTL is a safe probe: it never signals the key as modified, and it does not delete it while alive.
+        foreach ttl {100 500 2500} {
+            R 0 unwatch
+            R 0 set $watched_key alive px $ttl
+            R 0 watch $watched_key
+            set remaining [R 0 pttl $watched_key]
+            if {$remaining > 0} break
+        }
+        assert_morethan $remaining 0 "the WATCHed key expired before WATCH ran, even with a ${ttl}ms TTL"
+
+        # Wait for the TTL to elapse. The key stays in the keyspace because active expiry is off and no
+        # command reads it in the meantime.
         set keys_before [R 0 dbsize]
-        after 100
+        after [expr {$remaining + 50}]
         assert_equal $keys_before [R 0 dbsize]
 
         R 0 multi
@@ -62,7 +77,7 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         set reply [R 0 exec]
         R 0 debug set-active-expire 1
 
-        assert_equal {} $reply
+        assert_equal {} $reply "EXEC committed even though the WATCHed key expired after WATCH"
         assert_equal 0 [R 0 exists $transaction_key]
     }
 

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -56,13 +56,18 @@ start_cluster 1 1 {tags {external:skip cluster}} {
         # The key must still be alive when WATCH runs, otherwise the server remembers it as already expired
         # and deliberately lets EXEC commit. A round trip can take tens of milliseconds under valgrind, so
         # start with a short TTL and retry with a longer one until PTTL confirms the key outlived WATCH.
-        # PTTL is a safe probe: it never signals the key as modified, and it does not delete it while alive.
+        # PTTL cannot abort EXEC in the case we keep, because it does not touch a key that is still alive.
         foreach ttl {100 500 2500} {
-            R 0 unwatch
             R 0 set $watched_key alive px $ttl
             R 0 watch $watched_key
             set remaining [R 0 pttl $watched_key]
             if {$remaining > 0} break
+
+            # This tier lost the race. PTTL found the key already expired, and looking it up lazily
+            # deleted it and signalled it as modified, which dirtied this client's CAS. Clear that
+            # before re-arming, or a later winning tier would inherit the dirty flag and EXEC would
+            # abort for the wrong reason, leaving the test green without exercising anything.
+            R 0 unwatch
         }
         assert_morethan $remaining 0 "the WATCHed key expired before WATCH ran, even with a ${ttl}ms TTL"
 

--- a/tests/unit/cluster/misc.tcl
+++ b/tests/unit/cluster/misc.tcl
@@ -63,10 +63,12 @@ start_cluster 1 1 {tags {external:skip cluster}} {
             set remaining [R 0 pttl $watched_key]
             if {$remaining > 0} break
 
-            # This tier lost the race. PTTL found the key already expired, and looking it up lazily
-            # deleted it and signalled it as modified, which dirtied this client's CAS. Clear that
-            # before re-arming, or a later winning tier would inherit the dirty flag and EXEC would
-            # abort for the wrong reason, leaving the test green without exercising anything.
+            # This tier lost the race, and the client is now watching a key that no longer exists:
+            # PTTL's lookup lazily deleted the already-expired key. That deletion does not dirty the
+            # CAS, but it does clear the watch entry's expired flag (src/multi.c:481-490), so the next
+            # tier's SET re-creates a key this client still watches and that dirties the CAS. Drop the
+            # watch before re-arming, or a winning tier would inherit the dirty flag, EXEC would abort
+            # for the wrong reason, and the test would pass without exercising anything.
             R 0 unwatch
         }
         assert_morethan $remaining 0 "the WATCHed key expired before WATCH ran, even with a ${ttl}ms TTL"


### PR DESCRIPTION
**Not for upstream as-is — this is for your hand review.** Base is `upstream-unstable`, a clean mirror of `valkey-io/valkey:unstable` @ `11a74cf24`, so the diff is exactly the one commit.

## The failure

`WATCHed key in another slot that expired aborts EXEC` in `tests/unit/cluster/misc.tcl` failed in **14 of the last 14** scheduled `daily.yml` runs, only ever in the valgrind `cluster` shards (`test-valgrind-test (cluster)` and `test-valgrind-no-malloc-usable-size-test (cluster)`). Upstream issue: valkey-io/valkey#4407.

```
Expected '' to be equal to 'OK' (context: type eval line 21 cmd {assert_equal {} $reply} proc ::test)
```

`assert_equal` is `proc assert_equal {value expected}`, so that message means the *value* was `''` and the *expected* was `'OK'` — i.e. `EXEC` returned `OK`. It committed instead of aborting.

## Root cause — test bug, not a server bug

- `src/multi.c:399` — `watchForKey()` records `wk->expired = keyIsExpired(c->db, key)` at `WATCH` time.
- `src/multi.c:457` — `isWatchedKeyExpired()` does `if (wk->expired) continue;`.
- `src/multi.c:207` — `execCommand()` only sets `dirty_cas` when `isWatchedKeyExpired()` is true.

A key that was *already* logically expired when `WATCH` ran deliberately does **not** abort `EXEC`. The test did `SET $watched_key alive px 50` and then `WATCH`, racing that 50 ms window.

What makes it fire is more specific than "valgrind is slow". Instrumenting the test under valgrind shows a **one-time first-write cost**, not uniform slowness:

```
PROBE set_ms=61 watch_ms=21 pttl=-2     <-- first iteration on a fresh server
PROBE set_ms=1  watch_ms=1  pttl=47
PROBE set_ms=8  watch_ms=1  pttl=42
PROBE set_ms=1  watch_ms=1  pttl=49     ... 17 more, all 1-2 ms
```

The first write to that key/slot costs ~61 ms and the following `WATCH` another ~21 ms — 82 ms elapsed, so the key is already gone and `wk->expired = 1`. Every later iteration is 1-2 ms. That one-off cost straddling the 50 ms TTL is what produces the ~50% rate, and it explains why failing and passing runs have identical total durations (~190 ms vs 180-189 ms).

## The fix

Escalating TTL tiers (100 / 500 / 2500 ms) with a `PTTL` guard that confirms the key actually outlived `WATCH`. The retry *is* the warm-up: its first iteration absorbs the one-time cost, so tier 2 runs at steady-state latency. It adapts instead of hard-coding a magic TTL.

`PTTL` is a safe probe here — `ttlGenericCommand` (`src/expire.c:899`) uses `LOOKUP_NOTOUCH` and never calls `signalModifiedKey`, and `lookupKey` (`src/db.c:82-127`) only deletes via `expireIfNeeded` when the key is already expired, which is exactly the case the guard rejects anyway. So nothing new can dirty the CAS, and the existing `dbsize` before/after check still proves expiry is the only possible abort cause. The wait is now derived from the `PTTL` the server reported rather than a fixed sleep.

## Validation

| | run | result |
|---|---|---|
| Baseline, unpatched | [33291236045](https://github.com/madolson/valkey/actions/runs/33291236045) | **4 / 8 failed**, all with the identical assertion |
| Post-fix | [33291635031](https://github.com/madolson/valkey/actions/runs/33291635031) | **0 / 10 failed** |

All 10 post-fix attempts genuinely ran the test (every job log has `[ok]: WATCHed key in another slot that expired aborts EXEC` at 181-203 ms, and no attempt needed to escalate past the 100 ms tier). Also: non-valgrind `./runtest --single unit/cluster/misc` → 15 passed; local valgrind with the CI flags → 15 passed. Deliberately breaking the guard (1/2/3 ms tiers plus a 20 ms sleep) produces the intended diagnostic instead of the old backwards message:

```
Expected '-2' to be more than '0' (detail: the WATCHed key expired before WATCH ran, even with a 3ms TTL)
```

## Two things for you to weigh

1. I left `assert_equal {} $reply` argument order alone — `assert_equal <literal-expected> <actual>` is the dominant convention in this repo — and used the third `detail` argument to fix the unreadable message. Tell me if you would rather correct the order repo-wide.
2. **Adjacent at-risk test, not currently failing:** `Key lazy expires during key migration` at line 6 of the same file does `R 0 set FOO BAR PX 10` then `after 11` — a 1 ms margin. It survives today only because the first-write spike pushes the key *further* past expiry, which happens to be the direction it needs. Worth pre-emptive hardening.