### PR TITLE
Tests: record exceptions and timeouts in --failures-output

### DIFF
--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -501,6 +501,12 @@ proc read_from_test_client fd {
         }
     } elseif {$status eq {exception}} {
         puts "\[[colorstr red $status]\]: $data"
+        # Exceptions are raised outside test bodies, e.g. by an assertion in a start_server setup
+        # block, so they never reach the {err} branch above and were never added to ::failed_tests.
+        # Without recording one here the job fails while --failures-output reports an empty list,
+        # and the failure is invisible to the test failure detector.
+        lappend ::failed_tests [format_exception_failure $data]
+        incr ::err_count
         if {[catch {write_test_failures} err]} {
             puts "Warning: Failed to write test failures: $err"
         }
@@ -629,6 +635,34 @@ proc print_test_summary {} {
     puts "\nTest Summary: [colorstr bold-green $::ok_count] passed, [colorstr bold-red $::err_count] failed"
 }
 
+# Reduce an exception report to a single line that write_test_failures can attribute to a test file.
+# The report is a summary line followed by a Tcl stack trace. Frames in tests/support are harness
+# plumbing, so the innermost frame outside it is the useful location; fall back to the innermost
+# frame of any kind. The trace is flattened because write_test_failures parses one line per failure.
+proc format_exception_failure {data} {
+    set lines [split $data "\n"]
+    set summary [string trim [lindex $lines 0]]
+
+    set test_file "unknown"
+    foreach line $lines {
+        if {![regexp {(tests/\S+\.tcl):\d+} $line -> candidate]} continue
+        if {![string match "tests/support/*" $candidate]} {
+            set test_file $candidate
+            break
+        } elseif {$test_file eq "unknown"} {
+            set test_file $candidate
+        }
+    }
+
+    set trace {}
+    foreach line [lrange $lines 1 end] {
+        set line [string trim $line]
+        if {$line ne ""} {lappend trace $line}
+    }
+
+    return "\[exception\]: $summary in $test_file [join $trace {; }]"
+}
+
 proc write_test_failures {} {
     if {$::failures_output_file eq ""} {
         return
@@ -636,7 +670,10 @@ proc write_test_failures {} {
 
     set failures {}
     foreach failed $::failed_tests {
-        if {[string match {*\[*TIMEOUT*\]*} $failed]} continue
+        # A timeout names a test and a file just like an ordinary failure, so it is reported as one.
+        # The classes below are still dropped because they carry no stable test identity: their text
+        # is a raw tool report (valgrind/sanitizer), an executable path, or contains a pid, so every
+        # occurrence would look like a distinct failure to the detector and open a fresh issue.
         if {[string match {*Sanitizer error*} $failed]} continue
         if {[string match {*Valgrind error*} $failed]} continue
         if {[string match {*Can't start*} $failed]} continue

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -636,16 +636,19 @@ proc print_test_summary {} {
 }
 
 # Reduce an exception report to a single line that write_test_failures can attribute to a test file.
-# The report is a summary line followed by a Tcl stack trace. Frames in tests/support are harness
-# plumbing, so the innermost frame outside it is the useful location; fall back to the innermost
-# frame of any kind. The trace is flattened because write_test_failures parses one line per failure.
+# The report is a summary line followed by a stack trace, innermost frame first. Frames in
+# tests/support are harness plumbing, so prefer the innermost frame outside it. Two trace formats
+# reach us, matching the two branches in test_client_main: the pretty one from stacktrace.tcl
+# ("at tests/x.tcl:12") and raw ::errorInfo for builtin errors ('(file "tests/x.tcl" line 12)').
+# The trace is flattened because write_test_failures parses one line per failure.
 proc format_exception_failure {data} {
     set lines [split $data "\n"]
     set summary [string trim [lindex $lines 0]]
 
     set test_file "unknown"
     foreach line $lines {
-        if {![regexp {(tests/\S+\.tcl):\d+} $line -> candidate]} continue
+        if {![regexp {(tests/\S+\.tcl):\d+} $line -> candidate] &&
+            ![regexp {\(file "[^"]*?(tests/\S+\.tcl)" line \d+\)} $line -> candidate]} continue
         if {![string match "tests/support/*" $candidate]} {
             set test_file $candidate
             break
@@ -687,7 +690,11 @@ proc write_test_failures {} {
         if {[regexp {\[(\w+)\]:\s*(.+?)\s+in\s+(tests/\S+\.tcl)\s*(.*)} $failed -> status test_name test_file error_msg]} {
             # Successfully parsed
         } else {
-            set test_name $failed
+            # No usable location. Keep the leading status token if there is one, so the entry is
+            # still classifiable rather than silently reported as an ordinary "err".
+            if {![regexp {^\[(\w+)\]:\s*(.+)} $failed -> status test_name]} {
+                set test_name $failed
+            }
             set test_file "unknown"
             set error_msg $failed
         }

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -409,6 +409,18 @@ proc test_server_cron {} {
                     set test_name $tn
                 }
                 set test_name [string trim $test_name]
+                # Some client states carry a pid or a socket handle instead of a test name, e.g.
+                # "(SPAWNED SERVER) pid:123" or "ASSIGNED: sock12 (unit/type/list)". Those
+                # identifiers differ on every run, so reduce them to the part that is stable:
+                # the state itself, or the unit that was assigned. A sleeping client is not the
+                # one that hung, so it is not reported at all.
+                if {[regexp {^pid:\d+$} $test_name]} {
+                    regexp {^\(([^)]*)\)} $task -> test_name
+                } elseif {[regexp {^ASSIGNED:\s+\S+\s+(.*)$} $task -> assigned]} {
+                    set test_name "assigned $assigned"
+                } elseif {[string match "SLEEPING,*" $task]} {
+                    set test_name ""
+                }
                 if {[string length $test_name]} {
                     set file {}
                     if {[info exist ::active_clients_file($fd)]} {


### PR DESCRIPTION
**For your hand review.** Base is `upstream-unstable`, a clean mirror of `valkey-io/valkey:unstable` @ `11a74cf24`.

This is not a flaky-test fix — it is the reason one of the flakiest failures in the daily has no upstream issue. I'd suggest landing this before the individual test fixes, because it changes what the daily can tell us.

## The gap

`test-failure-detector.yml` builds issues from the `all-test-failures` artifact, which comes from `--failures-output`. Two mechanisms keep failures out of that file.

**1. Exceptions are never recorded.** `tests/test_helper.tcl:502`:

```tcl
} elseif {$status eq {exception}} {
    puts "\[[colorstr red $status]\]: $data"
    if {[catch {write_test_failures} err]} { ... }
    kill_clients
    force_kill_all_servers
    exit 1
```

It *calls* `write_test_failures`, but the exception was never appended to `::failed_tests`, so the file is written containing only whatever earlier failures existed. An assertion that fires outside a test body — e.g. in a `start_server` setup block — therefore produces a job that fails while reporting zero failures.

**2. Five classes are explicitly skipped** in `write_test_failures` (`tests/test_helper.tcl:638`): `[TIMEOUT]`, `Sanitizer error`, `Valgrind error`, `Can't start`, `Check for memory leaks`.

## Measured impact

Over the last 14 scheduled daily runs, the valgrind `integration-type` shard failed in **8 of 14** runs. All **12** of those job failures are the same exception:

```
[exception]: Executing test client: assertion:process didn't stop.
 in wait_process_paused at tests/integration/dual-channel-replication.tcl:832
 in start_server at tests/integration/dual-channel-replication.tcl:784
```

Every one of those jobs uploaded a **141-byte** `all-test-failures` artifact containing `[]`. Two weeks of a two-in-three failure rate, no issue, no comment, no history. I only found it by noticing that some failed jobs had empty artifacts.

Separately, `test-valgrind-no-malloc-usable-size-misc` on 2026-08-24 failed with `[TIMEOUT]: block time is equal to timer period in tests/unit/moduleapi/blockedclient.tcl` — also unreported, also an empty artifact.

## The change

Record the exception, reduced to one line whose location is the innermost stack frame **outside** `tests/support` (those frames are harness plumbing — `fail`, `wait_for_condition` — and would attribute every exception to `tests/support/test.tcl`). The trace is flattened onto the same line because `write_test_failures` parses one line per failure. Falls back to the innermost frame of any kind, then to `unknown`.

Timeouts already name a test and a file, so they are no longer dropped.

I left `Sanitizer error` / `Valgrind error` / `Can't start` / `Check for memory leaks` skipped, and added a comment saying why: their text is a raw tool report, an executable path, or contains a pid, so each occurrence looks like a distinct failure and would open a fresh issue every night. **That's the part I'd like your call on** — surfacing valgrind errors is arguably the whole point of a valgrind job, but it needs a stable synthetic identity (e.g. one issue per class, detail in the body) rather than just removing the skip. Happy to do that as a follow-up if you want it.

## Verification

Synthetic probe — a test file with one ordinary in-test failure plus a `fail` in the `start_server` body, which is the exact shape of the daily failure:

Before:
```json
[
  {"test_name": "probe: a normal recorded failure", "test_file": "tests/unit/zz-exc-probe.tcl",
   "status": "err", "error": "Expected '1' to be equal to '2' (context: ...)"}
]
```

After:
```json
[
  {"test_name": "probe: a normal recorded failure", "test_file": "tests/unit/zz-exc-probe.tcl",
   "status": "err", "error": "Expected '1' to be equal to '2' (context: ...)"},
  {"test_name": "Executing test client: assertion:synthetic setup-body failure.",
   "test_file": "tests/unit/zz-exc-probe.tcl", "status": "exception",
   "error": "in fail at tests/support/test.tcl:10; in start_server at tests/unit/zz-exc-probe.tcl:7; ..."}
]
```

Note `test_file` correctly skips the `tests/support/test.tcl` frame and lands on the real file. Fed the real F-02 trace through the formatter and the existing regexp, it yields `test_file=tests/integration/dual-channel-replication.tcl` and `status=exception` — a stable title that dedupes to one issue. Also checked the two degenerate cases (support-only trace, no frames at all) and that a `[TIMEOUT]` line now survives the filters and parses.

One judgement call: I kept `incr ::err_count` in the exception branch for consistency with the `err` branch. It has no observable effect today because `exit 1` runs before `print_test_summary`, but it is correct if that path ever changes.