### PR TITLE
rax: allocate insert-path nodes at their final size

### DIFF
--- a/src/rax.c
+++ b/src/rax.c
@@ -168,20 +168,84 @@ static inline void raxStackFree(raxStack *ts) {
      ((n)->iscompr ? sizeof(raxNode *) : sizeof(raxNode *) * (n)->size) + \
      (((n)->iskey && !(n)->isnull) * sizeof(void *)))
 
+/* Bytes a non compressed node with 'children' children needs, not counting the
+ * value pointer. Must stay in sync with raxNodeCurrentLength(). */
+static inline size_t raxNodeSize(size_t children) {
+    return sizeof(raxNode) + children + raxPadding(children) + sizeof(raxNode *) * children;
+}
+
+/* Bytes a compressed node holding 'chars' characters needs, not counting the
+ * value pointer. A compressed node has a single child whatever its length. */
+static inline size_t raxComprNodeSize(size_t chars) {
+    return sizeof(raxNode) + chars + raxPadding(chars) + sizeof(raxNode *);
+}
+
+/* Ask raxNewNodeSized() for exactly the bytes the node needs. */
+#define RAX_NODE_SIZE_EXACT 0
+
 /* Allocate a new non compressed node with the specified number of children.
  * If datafield is true, the allocation is made large enough to hold the
  * associated data pointer.
+ *
+ * 'nodesize' is the number of bytes to request from the allocator, raised to the
+ * minimum a node with that layout needs, so RAX_NODE_SIZE_EXACT asks for exactly
+ * that minimum. Requesting more is useful when the caller knows the node is
+ * about to grow, since the extra room removes the following reallocation.
+ *
+ * If 'cap' is not NULL it receives the number of bytes of the new allocation
+ * that are safe to write to, for raxResizeNode() to use later.
  * Returns the new node pointer. On out of memory NULL is returned. */
-raxNode *raxNewNode(size_t children, int datafield) {
-    size_t nodesize = sizeof(raxNode) + children + raxPadding(children) + sizeof(raxNode *) * children;
-    if (datafield) nodesize += sizeof(void *);
+static raxNode *raxNewNodeSized(size_t children, int datafield, size_t nodesize, size_t *cap) {
+    size_t minsize = raxNodeSize(children);
+    if (datafield) minsize += sizeof(void *);
+    if (nodesize < minsize) nodesize = minsize;
     raxNode *node = rax_malloc(nodesize);
     if (node == NULL) return NULL;
     node->iskey = 0;
     node->isnull = 0;
     node->iscompr = 0;
     node->size = children;
+    if (cap) *cap = rax_ptr_usable_size(node);
     return node;
+}
+
+/* Make sure node 'n' has room for at least 'newsize' bytes, where '*cap' is the
+ * room it currently has and is updated if the node is reallocated.
+ *
+ * Allocators round small allocations up to a size class, so the node often
+ * already has the room needed and the reallocation - which for a growing small
+ * allocation means malloc + copy + free - can be skipped. The node content is
+ * never moved when this happens, so callers must use the returned pointer
+ * exactly as they would use the result of a realloc().
+ *
+ * '*cap' must come from rax_ptr_usable_size() and never from
+ * rax_ptr_alloc_size(), which counts bytes that are not writable.
+ * Returns NULL on out of memory, leaving 'n' untouched. */
+static inline raxNode *raxResizeNode(raxNode *n, size_t newsize, size_t *cap) {
+    if (newsize <= *cap) return n;
+    raxNode *newn = rax_realloc(n, newsize);
+    if (newn != NULL) *cap = rax_ptr_usable_size(newn);
+    return newn;
+}
+
+/* Number of bytes to allocate for the node that will represent the remaining
+ * 'rem' characters of the key being inserted, that is, the node
+ * raxAddChild()/raxCompressNode() is about to create as their new child. The
+ * node is created empty and then immediately turned into a compressed node, a
+ * single child node, or a key holding node: allocating the final size right
+ * away removes that reallocation. */
+static inline size_t raxSuffixNodeSize(size_t rem, int hasdata) {
+    if (rem == 0) {
+        /* The child is the node holding the value of the inserted key. */
+        return sizeof(raxNode) + raxPadding(0) + (hasdata ? sizeof(void *) : 0);
+    }
+    if (rem == 1) {
+        /* A single character left: the child gets one non compressed child. */
+        return raxNodeSize(1);
+    }
+    /* More characters left: the child becomes a compressed node. */
+    size_t comprsize = rem > RAX_NODE_MAX_SIZE ? RAX_NODE_MAX_SIZE : rem;
+    return raxComprNodeSize(comprsize);
 }
 
 /* Allocate a new rax and return its pointer. On out of memory the function
@@ -191,7 +255,7 @@ rax *raxNew(void) {
     if (rax == NULL) return NULL;
     rax->numele = 0;
     rax->numnodes = 1;
-    rax->head = raxNewNode(0, 0);
+    rax->head = raxNewNodeSized(0, 0, RAX_NODE_SIZE_EXACT, NULL);
     rax->alloc_size = rax_ptr_alloc_size(rax) + rax_ptr_alloc_size(rax->head);
     if (rax->head == NULL) {
         rax_free(rax);
@@ -203,10 +267,10 @@ rax *raxNew(void) {
 
 /* realloc the node to make room for auxiliary data in order
  * to store an item in that node. On out of memory NULL is returned. */
-raxNode *raxReallocForData(raxNode *n, void *data) {
+raxNode *raxReallocForData(raxNode *n, void *data, size_t *cap) {
     if (data == NULL) return n; /* No reallocation needed, setting isnull=1 */
     size_t curlen = raxNodeCurrentLength(n);
-    return rax_realloc(n, curlen + sizeof(void *));
+    return raxResizeNode(n, curlen + sizeof(void *), cap);
 }
 
 /* Set the node auxiliary data to the specified pointer. */
@@ -236,10 +300,20 @@ void *raxGetData(raxNode *n) {
  * the new child was stored, which is useful for the caller to replace the
  * child pointer if it gets reallocated.
  *
+ * 'childsize' is the number of bytes to allocate for the new child, see
+ * raxNewNodeSized(): the caller knows the shape the child is about to be
+ * turned into, so the child can be allocated at its final size.
+ *
  * On success the new parent node pointer is returned (it may change because
  * of the realloc, so the caller should discard 'n' and use the new value).
  * On out of memory NULL is returned, and the old node is still valid. */
-raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode ***parentlink) {
+raxNode *raxAddChild(raxNode *n,
+                     unsigned char c,
+                     raxNode **childptr,
+                     raxNode ***parentlink,
+                     size_t childsize,
+                     size_t *cap,
+                     size_t *childcap) {
     assert(n->iscompr == 0);
 
     size_t curlen = raxNodeCurrentLength(n);
@@ -249,11 +323,12 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
                   success at the end. */
 
     /* Alloc the new child we will link to 'n'. */
-    raxNode *child = raxNewNode(0, 0);
+    raxNode *child = raxNewNodeSized(0, 0, childsize, childcap);
     if (child == NULL) return NULL;
 
-    /* Make space in the original node. */
-    raxNode *newn = rax_realloc(n, newlen);
+    /* Make space in the original node, reusing the allocation if it is already
+     * large enough. */
+    raxNode *newn = raxResizeNode(n, newlen, cap);
     if (newn == NULL) {
         rax_free(child);
         return NULL;
@@ -289,7 +364,7 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
      * a child "c" in our case pos will be = 2 after the end of the following
      * loop. */
     int pos;
-    for (pos = 0; pos < n->size; pos++) {
+    for (pos = 0; pos < (int)n->size; pos++) {
         if (n->data[pos] > c) break;
     }
 
@@ -377,8 +452,17 @@ raxNode *raxAddChild(raxNode *n, unsigned char c, raxNode **childptr, raxNode **
  *
  * The function also returns a child node, since the last node of the
  * compressed chain cannot be part of the chain: it has zero children while
- * we can only compress inner nodes with exactly one child each. */
-raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **child) {
+ * we can only compress inner nodes with exactly one child each.
+ *
+ * 'childsize' is the number of bytes to allocate for that child, see
+ * raxNewNodeSized(). */
+raxNode *raxCompressNode(raxNode *n,
+                         unsigned char *s,
+                         size_t len,
+                         raxNode **child,
+                         size_t childsize,
+                         size_t *cap,
+                         size_t *childcap) {
     assert(n->size == 0 && n->iscompr == 0);
     void *data = NULL; /* Initialized only to avoid warnings. */
     size_t newsize;
@@ -386,16 +470,16 @@ raxNode *raxCompressNode(raxNode *n, unsigned char *s, size_t len, raxNode **chi
     debugf("Compress node: %.*s\n", (int)len, s);
 
     /* Allocate the child to link to this node. */
-    *child = raxNewNode(0, 0);
+    *child = raxNewNodeSized(0, 0, childsize, childcap);
     if (*child == NULL) return NULL;
 
     /* Make space in the parent node. */
-    newsize = sizeof(raxNode) + len + raxPadding(len) + sizeof(raxNode *);
+    newsize = raxComprNodeSize(len);
     if (n->iskey) {
         data = raxGetData(n); /* To restore it later. */
         if (!n->isnull) newsize += sizeof(void *);
     }
-    raxNode *newn = rax_realloc(n, newsize);
+    raxNode *newn = raxResizeNode(n, newsize, cap);
     if (newn == NULL) {
         rax_free(*child);
         return NULL;
@@ -513,8 +597,8 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         debugf("### Insert: node representing key exists\n");
         /* Make space for the value pointer if needed. */
         if (!h->iskey || (h->isnull && overwrite)) {
-            size_t oldalloc = rax_ptr_alloc_size(h);
-            h = raxReallocForData(h, data);
+            size_t oldalloc = rax_ptr_alloc_size(h), hcap = rax_ptr_usable_size(h);
+            h = raxReallocForData(h, data, &hcap);
             if (h) {
                 memcpy(parentlink, &h, sizeof(h));
                 rax->alloc_size = rax->alloc_size - oldalloc + rax_ptr_alloc_size(h);
@@ -688,8 +772,14 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         size_t nodesize;
 
         /* 2: Create the split node. Also allocate the other nodes we'll need
-         *    ASAP, so that it will be simpler to handle OOM. */
-        raxNode *splitnode = raxNewNode(1, split_node_is_key);
+         *    ASAP, so that it will be simpler to handle OOM.
+         *    The split node always gets a second child right away (the
+         *    mismatching character of the key being inserted), so allocate the
+         *    room for it now and let raxAddChild() reuse the allocation. */
+        size_t splitsize = sizeof(raxNode) + 2 + raxPadding(2) + sizeof(raxNode *) * 2;
+        if (split_node_is_key) splitsize += sizeof(void *);
+        size_t splitalloc = 0;
+        raxNode *splitnode = raxNewNodeSized(1, split_node_is_key, splitsize, &splitalloc);
         raxNode *trimmed = NULL;
         raxNode *postfix = NULL;
 
@@ -713,7 +803,7 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             return 0;
         }
         splitnode->data[0] = h->data[j];
-        rax->alloc_size += rax_ptr_alloc_size(splitnode);
+        rax->alloc_size += splitalloc;
 
         if (j == 0) {
             /* 3a: Replace the old node with the split node. */
@@ -835,9 +925,10 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
 
     /* We walked the radix tree as far as we could, but still there are left
      * chars in our string. We need to insert the missing nodes. */
+    size_t hcap = rax_ptr_usable_size(h);
     while (i < len) {
         raxNode *child;
-        size_t oldalloc = rax_ptr_alloc_size(h);
+        size_t childcap, oldalloc = rax_ptr_alloc_size(h);
 
         /* If this node is going to have a single child, and there
          * are other characters, so that that would result in a chain
@@ -846,7 +937,8 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
             debugf("Inserting compressed node\n");
             size_t comprsize = len - i;
             if (comprsize > RAX_NODE_MAX_SIZE) comprsize = RAX_NODE_MAX_SIZE;
-            raxNode *newh = raxCompressNode(h, s + i, comprsize, &child);
+            raxNode *newh = raxCompressNode(h, s + i, comprsize, &child,
+                                            raxSuffixNodeSize(len - i - comprsize, data != NULL), &hcap, &childcap);
             if (newh == NULL) goto oom;
             h = newh;
             memcpy(parentlink, &h, sizeof(h));
@@ -855,7 +947,8 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         } else {
             debugf("Inserting normal node\n");
             raxNode **new_parentlink;
-            raxNode *newh = raxAddChild(h, s[i], &child, &new_parentlink);
+            raxNode *newh = raxAddChild(h, s[i], &child, &new_parentlink,
+                                        raxSuffixNodeSize(len - i - 1, data != NULL), &hcap, &childcap);
             if (newh == NULL) goto oom;
             h = newh;
             memcpy(parentlink, &h, sizeof(h));
@@ -864,10 +957,13 @@ int raxGenericInsert(rax *rax, unsigned char *s, size_t len, void *data, void **
         }
         rax->numnodes++;
         rax->alloc_size = rax->alloc_size - oldalloc + rax_ptr_alloc_size(h) + rax_ptr_alloc_size(child);
+        /* The child is the 'h' of the next iteration: carry its capacity over
+         * instead of asking the allocator for it again. */
         h = child;
+        hcap = childcap;
     }
     size_t oldalloc = rax_ptr_alloc_size(h);
-    raxNode *newh = raxReallocForData(h, data);
+    raxNode *newh = raxReallocForData(h, data, &hcap);
     if (newh == NULL) goto oom;
     h = newh;
     if (!h->iskey) rax->numele++;

--- a/src/rax.c
+++ b/src/rax.c
@@ -364,8 +364,15 @@ raxNode *raxAddChild(raxNode *n,
      * a child "c" in our case pos will be = 2 after the end of the following
      * loop. */
     int pos;
-    for (pos = 0; pos < (int)n->size; pos++) {
-        if (n->data[pos] > c) break;
+    /* Keys are very often inserted in increasing order (stream IDs, time
+     * prefixed keys, counters), in which case the new edge belongs at the end:
+     * check the last edge before scanning the whole array. */
+    if (n->size && n->data[n->size - 1] < c) {
+        pos = n->size;
+    } else {
+        for (pos = 0; pos < (int)n->size; pos++) {
+            if (n->data[pos] > c) break;
+        }
     }
 
     /* Now, if present, move auxiliary data pointer at the end

--- a/src/rax_malloc.h
+++ b/src/rax_malloc.h
@@ -41,5 +41,11 @@
 #define rax_malloc zmalloc
 #define rax_realloc zrealloc
 #define rax_free zfree
+/* Bytes the allocation is accounted for, used to maintain rax->alloc_size. */
 #define rax_ptr_alloc_size zmalloc_size
+/* Bytes of the allocation that are actually safe to write to. This is NOT the
+ * same as rax_ptr_alloc_size(): without HAVE_MALLOC_SIZE the accounted size
+ * includes zmalloc's own header, so using it as a capacity would overrun the
+ * block. Only ever use this one to decide whether a node has to grow. */
+#define rax_ptr_usable_size zmalloc_usable_size
 #endif


### PR DESCRIPTION
Two independent `rax` insert-path changes. Based on `valkey-io/valkey:unstable` @ 11a74cf24; base is this fork's `unstable` for review, retarget upstream when ready.

## 1. `rax: allocate insert-path nodes at their final size`

`raxGenericInsert()` creates nodes empty and then grows them. `raxNewNode()` mallocs an 8 byte node, `raxCompressNode()` or `raxReallocForData()` immediately reallocs it, and `raxAddChild()` reallocs the parent on every single child addition. These are small allocations, so the allocator cannot expand them in place and each realloc is a malloc + copy + free: 89% of reallocations return a new pointer on random 32 byte keys, 99.8% on a workload where every 8 byte boundary is a key.

Pass the size a node is about to need down to the allocation, and thread each node's writable capacity through the insert path so `raxAddChild()` can skip the realloc when the size class already has room. Reallocations per insert drop 3.00 -> 0.56.

Where insert cost actually goes, from `perf` with `raxLowWalk()` forced `noinline` (random 32B keys, 1M-key tree, 52,880 samples):

| bucket | share |
| --- | --- |
| tree walk (`raxLowWalk` + `memchr`) | 25.5% |
| realloc machinery + its internal copy | 30.7% |
| `alloc_size` bookkeeping | 7.8% |
| zmalloc/zrealloc/zfree's own accounting | 7.8% |
| malloc of new nodes | 7.8% |
| rax's own memmove/memcpy | 4.4% |
| insert logic incl. sorted-position scan | 12.9% |
| memory clearing | 0.0% |

**insert, ns/op**

| workload | before | after | |
| --- | --- | --- | --- |
| random 8B, 1M keys | 379 | 268 | −29% |
| random 32B, 1M keys | 426 | 296 | −31% |
| stream IDs, 1M keys | 215 | 110 | −49% |
| every-8B-boundary key | 308 | 224 | −27% |

**growing a node one child at a time, ns/child**

| target fanout | before | after | |
| --- | --- | --- | --- |
| 4 | 366 | 243 | −34% |
| 256 | 329 | 143 | −57% |

## 2. `rax: check the last edge first when adding a child`

`raxAddChild()` scans the whole edge array to find the insertion point. The scan is 8.6 steps per call for random keys but **50.8 for stream IDs**, because an append always walks every existing edge. Checking the last edge first:

| workload | before | after | |
| --- | --- | --- | --- |
| stream IDs (16B, 100/ms) | 173 | 153 | −12% |
| dense 8B counters | 188 | 125 | −33% |
| random 32B keys | 343 | 347 | +1% (noise floor) |

## Correctness

Node layout is unchanged, so `raxAllocSize()` and `numnodes` are identical before and after, and the read path is untouched — `raxFind()`, `raxNext()`, `raxPrev()`, `raxRemove()`, `raxIteratorNextStep()` compile to identical machine code (address-normalised `objdump`; `raxSeek()` differs only in an `assert()` `__LINE__` immediate).

No header change, no API change, no RDB/wire format change. `src/rax.c` and `src/rax_malloc.h` only.

- Differential harness vs stock: **byte-identical output** including `alloc_size` and forward/reverse iteration hashes, over random 8/16/32B keys, stream IDs, every-8B-boundary keys, variable-length keys, NULL values, the empty key, a remove-half pass, and 5 × 300k randomized insert/`raxTryInsert`/remove/find streams checked against a sorted-array model.
- `./runtest --single unit/type/stream --single unit/type/stream-cgroups --single unit/hashexpire --single unit/expire`: **636 passed, 0 failed.**
- Capacity handling verified under a `rax_malloc.h` shim mimicking zmalloc without `HAVE_MALLOC_SIZE` (accounted size includes a non-writable header): ASAN clean, where the same driver on the pre-fix code reports a `heap-buffer-overflow` in `raxCompressNode()`.

Not run here: `make -C src test-unit` — the system googletest is 1.8 (2018) with no gmock and fails to compile `test_hashtable.o` inside `/usr/include/c++/7/tr1/exp_integral.tcc`, unrelated to these changes. `clang-format-18` also unavailable locally (only v11, which reformats ~3000 lines of untouched `rax.c`), so style was matched by hand.