### PR TITLE
Make test-unit build reliably: fix bitcode lowering, missing prerequisite, and stale object list

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -800,7 +800,7 @@ distclean: clean
 test: $(ALL_BUILD_PREREQUISITES)
 	@(cd ..; VALKEY_PROG_SUFFIX="$(PROG_SUFFIX)" ./runtest)
 
-test-unit:
+test-unit: $(ENGINE_LIB_NAME)
 	@(cd unit && $(MAKE) test-unit)
 
 # valkey-unit-gtests

--- a/src/Makefile
+++ b/src/Makefile
@@ -801,11 +801,11 @@ test: $(ALL_BUILD_PREREQUISITES)
 	@(cd ..; VALKEY_PROG_SUFFIX="$(PROG_SUFFIX)" ./runtest)
 
 test-unit: $(ENGINE_LIB_NAME)
-	@(cd unit && $(MAKE) test-unit)
+	@(cd unit && $(MAKE) test-unit ENGINE_SERVER_OBJ="$(ENGINE_SERVER_OBJ)")
 
 # valkey-unit-gtests
 $(ENGINE_UNIT_GTESTS): $(ENGINE_LIB_NAME)
-	@(cd unit && $(MAKE) $(ENGINE_UNIT_GTESTS))
+	@(cd unit && $(MAKE) $(ENGINE_UNIT_GTESTS) ENGINE_SERVER_OBJ="$(ENGINE_SERVER_OBJ)")
 
 test-modules: $(SERVER_NAME)
 	@(cd ..; ./runtest-moduleapi)

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -137,12 +137,12 @@ $(WRAP_DIR):
 define wrap-object
 	@mkdir -p $(dir $@)
 	@if file $< | grep -q "LLVM bitcode"; then \
-		llc $< -filetype=obj -o $(WRAP_DIR)/$*_temp.o; \
-		python3 generate-redefine-syms.py $(WRAP_DIR)/$*_temp.o > $(WRAP_DIR)/$*-wrap-syms; \
-		llvm-objcopy --redefine-syms=$(WRAP_DIR)/$*-wrap-syms $(WRAP_DIR)/$*_temp.o $@; \
+		$(CC) -O2 -x ir -c $< -o $(WRAP_DIR)/$*_temp.o && \
+		python3 generate-redefine-syms.py $(WRAP_DIR)/$*_temp.o > $(WRAP_DIR)/$*-wrap-syms && \
+		llvm-objcopy --redefine-syms=$(WRAP_DIR)/$*-wrap-syms $(WRAP_DIR)/$*_temp.o $@ && \
 		rm -f $(WRAP_DIR)/$*_temp.o; \
 	else \
-		python3 generate-redefine-syms.py $< > $(WRAP_DIR)/$*-wrap-syms; \
+		python3 generate-redefine-syms.py $< > $(WRAP_DIR)/$*-wrap-syms && \
 		llvm-objcopy --redefine-syms=$(WRAP_DIR)/$*-wrap-syms $< $@; \
 	fi
 	@rm -f $(WRAP_DIR)/$*-wrap-syms

--- a/src/unit/Makefile
+++ b/src/unit/Makefile
@@ -125,6 +125,12 @@ TEST_WRAP_OBJ := $(addprefix $(WRAP_DIR)/, $(ALL_OBJECTS))
 # Homebrew does not add llvm/bin to PATH by default, so we check the standard
 # Homebrew prefix locations for both Apple Silicon (/opt/homebrew) and Intel (/usr/local).
 BREW_LLVM_BIN := $(firstword $(wildcard /opt/homebrew/opt/llvm/bin /usr/local/opt/llvm/bin))
+
+# Resolve CC before the PATH prepend below, so wrap-object lowers bitcode with
+# the same compiler the parent used to produce it. A bare CC=clang would
+# otherwise resolve to the Homebrew clang added to PATH below, which cannot read
+# Apple clang's IR.
+BITCODE_CC := $(shell command -v $(CC) 2>/dev/null || echo $(CC))
 ifneq ($(BREW_LLVM_BIN),)
   export PATH := $(BREW_LLVM_BIN):$(PATH)
 else
@@ -137,7 +143,7 @@ $(WRAP_DIR):
 define wrap-object
 	@mkdir -p $(dir $@)
 	@if file $< | grep -q "LLVM bitcode"; then \
-		$(CC) -O2 -x ir -c $< -o $(WRAP_DIR)/$*_temp.o && \
+		$(BITCODE_CC) -O2 -x ir -c $< -o $(WRAP_DIR)/$*_temp.o && \
 		python3 generate-redefine-syms.py $(WRAP_DIR)/$*_temp.o > $(WRAP_DIR)/$*-wrap-syms && \
 		llvm-objcopy --redefine-syms=$(WRAP_DIR)/$*-wrap-syms $(WRAP_DIR)/$*_temp.o $@ && \
 		rm -f $(WRAP_DIR)/$*_temp.o; \


### PR DESCRIPTION
## Problem

`make test-unit` does not work on macOS in the default configuration, and is fragile in three other ways. Four independent problems, one commit each.

**1. `test-unit` has no prerequisites.** `src/Makefile:803` recurses into `unit/` immediately. It is the only test target with nothing: `test:` has `$(ALL_BUILD_PREREQUISITES)` and `$(ENGINE_UNIT_GTESTS)` on the very next line already has `$(ENGINE_LIB_NAME)`. Two different failures follow, depending on whether `.make-settings` exists.

After `make clean`, `.make-settings` survives, so `ENGINE_SERVER_OBJ` is populated in the child and `wrapped/%.o: ../%.o` (`src/unit/Makefile:152`) has targets. Nothing builds `../%.o`, so GNU make falls back to its built-in implicit rule:

```
cc    -c -o ../acl.o ../acl.c
../compression_lz4.c:14:10: fatal error: 'lz4frame.h' file not found
../debug.c:37:10: fatal error: 'fpconv_dtoa.h' file not found
```

That `cc` carries none of the project CFLAGS and no `-I../../deps` paths, so it fails on whichever translation unit wins the parallel race. After `make distclean`, `.make-settings` is gone too, so `MALLOC` is empty and `JEMALLOC_CFLAGS` keeps its jemalloc-on default (`src/unit/Makefile:174-178`):

```
../allocator_defrag.h:5:10: fatal error: 'jemalloc/jemalloc.h' file not found
make[1]: *** [generated_wrappers.o] Error 1
```

There is also an ordering absurdity that is not macOS specific: on the old target the parent's `distclean`, including `(cd unit && make clean)`, runs from *inside* the unit sub-make, so the parent wipes `src/unit`'s working directory mid-build.

**2. `.make-settings` caches a stale source list.** `ENGINE_SERVER_OBJ` is written there but regenerated only when `FINAL_CFLAGS` or `FINAL_LDFLAGS` change (`src/Makefile:708-714`). Adding a `src/*.c` changes neither. `src/Makefile:473` re-assigns the variable after the `-include`, so the parent never notices, but `src/unit/Makefile` has no assignment of its own and built `wrapped/wrappedlibvalkey.a` from the old list:

```
Undefined symbols for architecture arm64:
  "_ztestDummyValue", referenced from:
make[1]: *** [valkey-unit-gtests] Error 1
```

This is the reason for the current folklore that you must `distclean` before `test-unit` after a branch switch.

**3. Bitcode objects are lowered by the wrong toolchain.** `src/Makefile:24-29` appends `-flto` whenever `OPTIMIZATION` is exactly `-O3` and the compiler is clang, so the server objects are LLVM bitcode, not Mach-O. The Darwin `--wrap` emulation then ran homebrew LLVM's `llc` over them:

```
LLVM ERROR: Unsupported stack probing method
Stack dump:
0.	Program arguments: llc ../acl.o -filetype=obj -o wrapped/acl_temp.o
2.	Running pass 'AArch64 Instruction Selection' on function '@ACLAddCommandCategory'
 #7 llvm::AArch64FunctionInfo::AArch64FunctionInfo(...) (libLLVM.dylib+0x20f99b8)
/bin/sh: line 1: 68637 Abort trap: 6           llc ../acl.o -filetype=obj -o wrapped/acl_temp.o
llvm-objcopy: error: 'wrapped/acl_temp.o': No such file or directory
```

Apple clang stamps every function with the Apple-private attribute `"probe-stack"="__chkstk_darwin"`, confirmed with `llvm-dis`:

```
attributes #0 = { nounwind ssp uwtable(sync) ... "probe-stack"="__chkstk_darwin" ... }
```

Upstream LLVM's AArch64 backend only accepts `"inline-asm"` there and calls `report_fatal_error` on anything else. Minimal reproduction, no Valkey involved:

```
$ printf 'int f(int x){int a[70000]; a[x]=x; return a[0];}\n' > lt.c
$ /usr/bin/clang -O3 -flto -c lt.c -o lt.o && file lt.o
lt.o: LLVM bitcode, wrapper
$ /opt/homebrew/opt/llvm/bin/llc lt.o -filetype=obj -o out.o
LLVM ERROR: Unsupported stack probing method
$ /usr/bin/clang -x ir -c lt.o -o out.o && file out.o
out.o: Mach-O 64-bit object arm64
```

**4. The wrap recipe swallows its own failures.** `@if ...; then A; B; C; fi` exits with the status of the last command in the branch, so a lowering failure never failed the target. A mismatched compiler produced 114 failures and 3202 lines of log, and make only failed at `ar`, 3189 lines after the first real error:

```
3088:ar: wrapped/acl.o: No such file or directory
3202:make: *** [wrapped/wrappedlibvalkey.a] Error 1
```

The symptom quoted in problem 3, `llvm-objcopy: error: ... No such file or directory`, is this bug hiding the actual error on the line above it.

## Fix

1. `test-unit: $(ENGINE_LIB_NAME)`, matching `$(ENGINE_UNIT_GTESTS)`. Prerequisite ordering is the only available fix: `src/unit/Makefile:4` does `-include ../.make-settings`, evaluated at parse time, so the existing `make-prerequisites` target at `src/unit/Makefile:170` cannot help.
2. Pass `ENGINE_SERVER_OBJ` on the recursive make command line, which takes precedence over the `-include`d assignment. The `.make-settings` line is deliberately **kept**: it is the only way a standalone `make -C src/unit` can get a value, and that Makefile has its own `.DEFAULT_GOAL`, `clean`, `distclean` and `valgrind` targets, so it is meant to be usable directly.
3. `$(CC) -O2 -x ir -c` instead of `llc`, keeping code generation inside one LLVM instead of handing one toolchain's IR to another. `-O2` is explicit because `llc` defaults to `-O2` while a clang driver with no `-O` uses the `-O0` pipeline, which is a 3.6x slowdown on the slowest unit test.
4. `&&`-chain both branches of `wrap-object`, and resolve `CC` before `src/unit/Makefile:129` prepends homebrew LLVM to `PATH`, so a bare `CC=clang` does not lower with a different clang than the one that compiled.

`llvm-objcopy` is still required, since Apple ships no `objcopy`, but it no longer performs code generation.

**On the alternative for 3:** keeping `llc` and adding a guard that fails with "rebuild with `OPT=...`" instead of an LLVM crash dump would be smaller, but it loses. It leaves macOS developers unable to run unit tests on a default `-O3` build, which is the default, and it treats toolchain drift as user error.

**What this does not guarantee.** `CC` is not persisted in `.make-settings`, so building with an explicit `CC` and then running `make test-unit` as a *separate* invocation still mismatches producer and consumer. Within one invocation `CC` propagates correctly, whether unset, on the command line, or in the environment. Persisting `CC` would close the gap but changes behavior for the whole build, not just tests, so it is out of scope here. See decision 2.

## Why CI is green today

`ci.yml:219-225` `build-macos-latest` sets `CC`/`CXX`/`AR`/`RANLIB` to homebrew LLVM, and homebrew clang does not emit the attribute that kills `llc`:

```
/usr/bin/clang                    probe-stack: "probe-stack"="__chkstk_darwin"   llc exit=134  LLVM ERROR
/opt/homebrew/opt/llvm/bin/clang  probe-stack: <none>                            llc exit=0
```

That is also the job that exercises the `-x ir` path on every PR. Note it is the **only** job that reaches this recipe, and it pins the newest homebrew LLVM, so CI structurally cannot catch an older-clang regression here.

## Decisions for the reviewer

1. **Drop the `PATH` prepend entirely?** It is now needed only for `llvm-objcopy`: `generate-redefine-syms.py` shells out to plain `nm`, Apple's `/usr/bin/nm` supports `--defined-only --extern-only`, and homebrew LLVM ships `llvm-nm` rather than `nm`, so `nm` resolves to Apple's either way. Using an absolute `llvm-objcopy` and deleting the prepend would remove this whole class of problem. Proposal: not in this PR, because it also changes how `CXX`, `ld` and `ar` resolve in every unit-test recipe and I cannot prove that safe.
2. **Persist `CC` in `.make-settings`?** Proposal: no, not here. It fixes the cross-invocation mismatch above but affects every build, not just tests.
3. **Deduplicate the two recursive lines** via `test-unit: $(ENGINE_UNIT_GTESTS)`? Proposal: no, it restructures a target this PR does not otherwise need to touch.

## Testing

macOS 26.6.2 arm64 (M4), Apple clang 17.0.0, GNU Make 3.81, homebrew LLVM 22.1.2, `MALLOC=libc`, default `OPT=-O3 -flto -fno-omit-frame-pointer`. All 116 top-level `src/*.o` are `LLVM bitcode, wrapper`, so the bitcode branch is exercised for all 123 `ENGINE_SERVER_OBJ` entries. Every run below is on the default configuration with **no** `OPT` override, which is the configuration that fails today.

| Case | Result |
|---|---|
| `make distclean && make && make test-unit` | 645/645 |
| `make clean && make -j10 test-unit` | 645/645, no `cc -c -o ../acl.o` cascade |
| `make distclean && make -j10 test-unit` as first command | 645/645 |
| `make -j1 test-unit` from distclean | 645/645 |
| `cd src/unit && rm -rf wrapped valkey-unit-gtests && make test-unit` | 645/645, archive has all 123 members |
| `make CC=clang -j10 test-unit` | 645/645, 0 backend errors |
| New `src/*.c` added, no distclean | 646/646 |

Each fix was also confirmed load-bearing by reverting only its hunk:

- Commit 1 reverted, `make clean && make -j10 test-unit`: the `cc -c -o ../acl.o ../acl.c` cascade above.
- Commit 2 reverted with a scratch `src/ztest_dummy.c` referenced from a real `TEST_F` so the symbol is required at link time: `Undefined symbols ... "_ztestDummyValue"`, exit 2, and `wrapped/ztest_dummy.o` absent from the `ar` line.
- Commit 2's `.make-settings` line deleted instead of kept: `ar rcs wrapped/wrappedlibvalkey.a` / `ar: no archive members specified`, i.e. standalone `make -C src/unit` breaks.
- Commit 3 reverted: `llc ../acl.o` aborts with SIGABRT, exit 134.
- Commit 4's `&&` reverted: 3202 log lines, 114 failures, make fails only at `ar`. With `&&`: 67 lines, 1 failure, stops at the first wrapped object.
- Commit 4's `CC` resolution reverted, `make CC=clang -j1 test-unit`: `clang -O2 -x ir -c ../acl.o`, `make[1]: *** [wrapped/acl.o] Error 1`, exit 2.

`-O2` versus `-O0` lowering, three runs of the slowest test (`QuicklistTest.quicklistComprassionPlainNode`):

```
-O2:  1.37s  1.42s  (and 1.44s in an earlier build)
-O0:  5.10s  5.15s  5.78s
```

`-O2` does not change symbol extraction: across all 123 objects, `generate-redefine-syms.py` output and the `nm --defined-only --extern-only | grep ' T '` sets are byte-identical between `-O0` and `-O2` lowering (0 diffs, 3733 `T` symbols).

**Linux**, by dry-run comparison rather than a real run. `make -n test-unit` on base versus this branch, normalized and set-compared on AL2 x86_64 with GNU Make 3.82: 258 unique commands each, and the only differences are the two intended ones.

```
===== only in FIX =====
(cd unit && make test-unit ENGINE_SERVER_OBJ="acl.o adlist.o ae.o ...
===== only in BASE =====
(cd unit && make test-unit)
```

No over-build: the nested `make libvalkey.a` reports `libvalkey.a is up to date`. Commits 3 and 4 touch only code inside `ifeq ($(uname_S), Darwin)` (`src/unit/Makefile:119-162`), and Linux links with `-Wl,--wrap` at `src/unit/Makefile:235-240`, never expanding `wrap-object`.

**What I could not test.** No real Linux run, only the dry-run comparison above. No Intel macOS. `BUILD_TLS=yes` fails with `ld: library 'ssl' not found`, which is pre-existing (`src/unit/Makefile:104` has `-lssl -lcrypto` with no `-L` for homebrew openssl) and untouched here, but note that no CI job runs `test-unit` with TLS on macOS, so nothing covers it. `SANITIZER=address` builds, wraps, archives and links correctly, but cannot run on this machine: a 3-line `int main(void){return 0;}` built with `-fsanitize=address` also hangs before `main`, so that is not this change. `MALLOC=jemalloc` passes. Not tested: `-m32`, `COVERAGE`, `BUILD_LUA=module`, `USE_LIBBACKTRACE=yes`, real GNU gcc, clang older than 17, and whether `-O2` versus `-O0` lowering changes any individual test's outcome rather than just its speed.

This was generated by AI but verified, with love, by a human.
